### PR TITLE
CSS processing fixes

### DIFF
--- a/lib/hashly.js
+++ b/lib/hashly.js
@@ -64,7 +64,7 @@ var createManifestEntryCss = function(fullPath, baseDir, targetDir, data) {
             path.resolve(path.dirname(fullPath), virtualPath);
 
         // do not handle css inlined data
-        if (virtualPath.startsWith("data:")) {
+        if (virtualPath.substring(0, 5) === "data:") {
         	return virtualPath;
         }
 

--- a/lib/hashly.js
+++ b/lib/hashly.js
@@ -77,8 +77,8 @@ var createManifestEntryCss = function(fullPath, baseDir, targetDir, data) {
             // find path of target css file to build correct relative path to hashed resource
             var relativePath = path.relative(baseDir, fullPath);
             var targetPath = path.resolve(targetDir, relativePath);
-            
-            return path.relative(path.dirname(targetPath), entry.hashedPathPhysical);
+
+            return unixifyPath(path.relative(path.dirname(targetPath), entry.hashedPathPhysical));
         }
         return entry.hashedPath;
     };


### PR DESCRIPTION
A couple of fixes to the CSS processor:

1. Change startsWith to substring to support older versions of node.

2. Fix an issue with incorrect path separators in rewritten CSS image URLs.